### PR TITLE
Two bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var destination = require('turf-destination');
  * //=result
  */
 
-module.exports = function (line, pt) {  
+module.exports = function(line, pt) {
   var coords;
   if (line.type === 'Feature') {
     coords = line.geometry.coordinates;
@@ -61,12 +61,12 @@ module.exports = function (line, pt) {
   return pointOnLine(pt, coords);
 };
 
-function pointOnLine (pt, coords) {
+function pointOnLine(pt, coords) {
   var units = 'miles';
   var closestPt = point([Infinity, Infinity], {
     dist: Infinity
   });
-  for(var i = 0; i < coords.length - 1; i++) {
+  for (var i = 0; i < coords.length - 1; i++) {
     var start = point(coords[i]);
     var stop = point(coords[i + 1]);
     //start
@@ -88,25 +88,25 @@ function pointOnLine (pt, coords) {
       stop.geometry.coordinates[1]
       );
     var intersectPt;
-    if(intersect) {
+    if (intersect) {
       var intersectPt = point(intersect);
       intersectPt.properties.dist = distance(pt, intersectPt, units);
     }
-    
-    if(start.properties.dist < closestPt.properties.dist) {
+
+    if (start.properties.dist < closestPt.properties.dist) {
       closestPt = start;
       closestPt.properties.index = i;
     }
-    if(stop.properties.dist < closestPt.properties.dist) {
-     closestPt = stop;
-     closestPt.properties.index = i;
+    if (stop.properties.dist < closestPt.properties.dist) {
+      closestPt = stop;
+      closestPt.properties.index = i;
     }
-    if(intersectPt && intersectPt.properties.dist < closestPt.properties.dist){ 
+    if (intersectPt && intersectPt.properties.dist < closestPt.properties.dist) {
       closestPt = intersectPt;
       closestPt.properties.index = i;
     }
   }
-  
+
   return closestPt;
 }
 
@@ -115,11 +115,11 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
   // if the lines intersect, the result contains the x and y of the intersection (treating the lines as infinite) and booleans for whether line segment 1 or line segment 2 contain the point
   var denominator, a, b, numerator1, numerator2,
     result = {
-    x: null,
-    y: null,
-    onLine1: false,
-    onLine2: false
-  };
+      x: null,
+      y: null,
+      onLine1: false,
+      onLine2: false
+    };
   denominator = ((line2EndY - line2StartY) * (line1EndX - line1StartX)) - ((line2EndX - line2StartX) * (line1EndY - line1StartY));
   if (denominator === 0) {
     if (result.x !== null && result.y !== null) {
@@ -148,7 +148,7 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
     result.onLine2 = true;
   }
   // if line1 and line2 are segments, they intersect if both of the above are true
-  if(result.onLine1 && result.onLine2){
+  if (result.onLine1 && result.onLine2) {
     return [result.x, result.y];
   } else {
     return false;

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var destination = require('turf-destination');
  * //=result
  */
 
-module.exports = function(line, pt) {
+module.exports = function (line, pt) {  
   var coords;
   if (line.type === 'Feature') {
     coords = line.geometry.coordinates;
@@ -61,12 +61,12 @@ module.exports = function(line, pt) {
   return pointOnLine(pt, coords);
 };
 
-function pointOnLine(pt, coords) {
+function pointOnLine (pt, coords) {
   var units = 'miles';
   var closestPt = point([Infinity, Infinity], {
     dist: Infinity
   });
-  for (var i = 0; i < coords.length - 1; i++) {
+  for(var i = 0; i < coords.length - 1; i++) {
     var start = point(coords[i]);
     var stop = point(coords[i + 1]);
     //start
@@ -75,51 +75,38 @@ function pointOnLine(pt, coords) {
     stop.properties.dist = distance(pt, stop, units);
     //perpendicular
     var direction = bearing(start, stop);
-    var perpendicularPt = destination(pt, 1000, direction + 90, units); // 1000 = gross
+    var perpendicularPt1 = destination(pt, 1000 , direction + 90, units); // 1000 = gross
+    var perpendicularPt2 = destination(pt, 1000 , direction - 90, units); // 1000 = gross
     var intersect = lineIntersects(
-      pt.geometry.coordinates[0],
-      pt.geometry.coordinates[1],
-      perpendicularPt.geometry.coordinates[0],
-      perpendicularPt.geometry.coordinates[1],
+      perpendicularPt1.geometry.coordinates[0],
+      perpendicularPt1.geometry.coordinates[1],
+      perpendicularPt2.geometry.coordinates[0],
+      perpendicularPt2.geometry.coordinates[1],
       start.geometry.coordinates[0],
       start.geometry.coordinates[1],
       stop.geometry.coordinates[0],
       stop.geometry.coordinates[1]
-    );
-    if (!intersect) {
-      perpendicularPt = destination(pt, 1000, direction - 90, units); // 1000 = gross
-      intersect = lineIntersects(
-        pt.geometry.coordinates[0],
-        pt.geometry.coordinates[1],
-        perpendicularPt.geometry.coordinates[0],
-        perpendicularPt.geometry.coordinates[1],
-        start.geometry.coordinates[0],
-        start.geometry.coordinates[1],
-        stop.geometry.coordinates[0],
-        stop.geometry.coordinates[1]
       );
-    }
-    perpendicularPt.properties.dist = Infinity;
     var intersectPt;
-    if (intersect) {
+    if(intersect) {
       var intersectPt = point(intersect);
       intersectPt.properties.dist = distance(pt, intersectPt, units);
     }
-
-    if (start.properties.dist < closestPt.properties.dist) {
+    
+    if(start.properties.dist < closestPt.properties.dist) {
       closestPt = start;
       closestPt.properties.index = i;
     }
-    if (stop.properties.dist < closestPt.properties.dist) {
-      closestPt = stop;
-      closestPt.properties.index = i;
+    if(stop.properties.dist < closestPt.properties.dist) {
+     closestPt = stop;
+     closestPt.properties.index = i;
     }
-    if (intersectPt && intersectPt.properties.dist < closestPt.properties.dist) {
+    if(intersectPt && intersectPt.properties.dist < closestPt.properties.dist){ 
       closestPt = intersectPt;
       closestPt.properties.index = i;
     }
   }
-
+  
   return closestPt;
 }
 
@@ -128,11 +115,11 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
   // if the lines intersect, the result contains the x and y of the intersection (treating the lines as infinite) and booleans for whether line segment 1 or line segment 2 contain the point
   var denominator, a, b, numerator1, numerator2,
     result = {
-      x: null,
-      y: null,
-      onLine1: false,
-      onLine2: false
-    };
+    x: null,
+    y: null,
+    onLine1: false,
+    onLine2: false
+  };
   denominator = ((line2EndY - line2StartY) * (line1EndX - line1StartX)) - ((line2EndX - line2StartX) * (line1EndY - line1StartY));
   if (denominator === 0) {
     if (result.x !== null && result.y !== null) {
@@ -161,7 +148,7 @@ function lineIntersects(line1StartX, line1StartY, line1EndX, line1EndY, line2Sta
     result.onLine2 = true;
   }
   // if line1 and line2 are segments, they intersect if both of the above are true
-  if (result.onLine1 && result.onLine2) {
+  if(result.onLine1 && result.onLine2){
     return [result.x, result.y];
   } else {
     return false;

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function pointOnLine(pt, coords) {
     //stop
     stop.properties.dist = distance(pt, stop, units);
     //perpendicular
-    var heightDistance = 2 * Math.max(start.properties.dist, stop.properties.dist);
+    var heightDistance = Math.max(start.properties.dist, stop.properties.dist);
     var direction = bearing(start, stop);
     var perpendicularPt1 = destination(pt, heightDistance, direction + 90, units);
     var perpendicularPt2 = destination(pt, heightDistance, direction - 90, units);

--- a/index.js
+++ b/index.js
@@ -74,9 +74,10 @@ function pointOnLine(pt, coords) {
     //stop
     stop.properties.dist = distance(pt, stop, units);
     //perpendicular
+    var heightDistance = 2 * Math.max(start.properties.dist, stop.properties.dist);
     var direction = bearing(start, stop);
-    var perpendicularPt1 = destination(pt, 1000 , direction + 90, units); // 1000 = gross
-    var perpendicularPt2 = destination(pt, 1000 , direction - 90, units); // 1000 = gross
+    var perpendicularPt1 = destination(pt, heightDistance, direction + 90, units);
+    var perpendicularPt2 = destination(pt, heightDistance, direction - 90, units);
     var intersect = lineIntersects(
       perpendicularPt1.geometry.coordinates[0],
       perpendicularPt1.geometry.coordinates[1],


### PR DESCRIPTION
Fix #1:

I replaced the 1000 miles number to a number which depends on the actual query. Let's say we want to intersect a point P with a line AB. The maximum distance between the line and the point cannot be more than the distance PA or PB, so I take the maximum between those two, and multiply it by 2 because we look 

Fix #3:

I draw only one line instead of 2, so we are sure to find the intersection even if the point is already on the line.
